### PR TITLE
fix(composer): Remove pre-update-cmd

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,10 +60,8 @@
             "php artisan optimize",
             "php artisan migrate --force"
         ],
-        "pre-update-cmd": [
-            "php artisan clear-compiled"
-        ],
         "post-update-cmd": [
+            "php artisan clear-compiled",
             "php artisan optimize"
         ]
     },


### PR DESCRIPTION
Can't rely on being able to run php artisan, before updating. [composer/composer#5066](https://github.com/composer/composer/issues/5066)

When installing without lockfile, Composer now behaves as upgrade. It also executes the `pre-upgrade-cmd` instead of `pre-install-cmd`. Behaviour with composer.lock available is not changed.

With the latest composer version, doing a fresh install will fail because the vendor files are not yet present.