### PR TITLE
Command order changes and step removal

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,9 +92,6 @@ cd hackathon-starter-pack
 # Copy .env.example to .env
 cp .env.example .env
 
-# Generate application secure key (in .env file)
-php artisan key:generate
-
 # Create a database (with mysql or postgresql)
 # And update .env file with database credentials
 # DB_CONNECTION=mysql
@@ -106,8 +103,8 @@ php artisan key:generate
 # Install Composer dependencies
 composer install
 
-# Run your migrations
-php artisan migrate
+# Generate application secure key (in .env file)
+php artisan key:generate
 
 php artisan serve
 ```


### PR DESCRIPTION
Changed order of the key:generate command to avoid the errors on first-time usage.
Removed the php artisan migrate command as it appears to be done as part of the composer install process anyway.